### PR TITLE
Make Id type overloaded over entity

### DIFF
--- a/cascade-api/src/Cascade/Api/Data/Id.hs
+++ b/cascade-api/src/Cascade/Api/Data/Id.hs
@@ -1,0 +1,18 @@
+module Cascade.Api.Data.Id
+  ( Id(..)
+  ) where
+
+import           Control.Lens.TH                ( makeWrapped )
+import           Data.Aeson                     ( FromJSON
+                                                , ToJSON
+                                                )
+import           Servant.API                    ( FromHttpApiData
+                                                , ToHttpApiData
+                                                )
+
+newtype Id (entity :: Type) = Id
+  { unId :: UUID }
+  deriving stock Generic
+  deriving newtype (Show, Eq, Ord, FromHttpApiData, ToHttpApiData, FromJSON, ToJSON)
+
+makeWrapped ''Id

--- a/cascade-api/src/Cascade/Api/Data/Prelude.hs
+++ b/cascade-api/src/Cascade/Api/Data/Prelude.hs
@@ -12,14 +12,6 @@ Portability : POSIX
 
 module Cascade.Api.Data.Prelude where
 
-import           Control.Lens.TH                ( makeWrapped )
-import           Data.Aeson                     ( FromJSON
-                                                , ToJSON
-                                                )
-import           Servant.API                    ( FromHttpApiData
-                                                , ToHttpApiData
-                                                )
-
 data family Readable (a :: Type)
 
 data family Creatable (a :: Type)
@@ -27,10 +19,3 @@ data family Creatable (a :: Type)
 data family Updatable (a :: Type)
 
 data family Deletable (a :: Type)
-
-newtype Id (entity :: Type) = Id
-  { unId :: UUID }
-  deriving stock Generic
-  deriving newtype (Show, Eq, Ord, FromHttpApiData, ToHttpApiData, FromJSON, ToJSON)
-
-makeWrapped ''Id

--- a/cascade-api/src/Cascade/Api/Data/Prelude.hs
+++ b/cascade-api/src/Cascade/Api/Data/Prelude.hs
@@ -12,6 +12,14 @@ Portability : POSIX
 
 module Cascade.Api.Data.Prelude where
 
+import           Control.Lens.TH                ( makeWrapped )
+import           Data.Aeson                     ( FromJSON
+                                                , ToJSON
+                                                )
+import           Servant.API                    ( FromHttpApiData
+                                                , ToHttpApiData
+                                                )
+
 data family Readable (a :: Type)
 
 data family Creatable (a :: Type)
@@ -19,3 +27,10 @@ data family Creatable (a :: Type)
 data family Updatable (a :: Type)
 
 data family Deletable (a :: Type)
+
+newtype Id (entity :: Type) = Id
+  { unId :: UUID }
+  deriving stock Generic
+  deriving newtype (Show, Eq, Ord, FromHttpApiData, ToHttpApiData, FromJSON, ToJSON)
+
+makeWrapped ''Id

--- a/cascade-api/src/Cascade/Api/Data/Project.hs
+++ b/cascade-api/src/Cascade/Api/Data/Project.hs
@@ -19,6 +19,7 @@ module Cascade.Api.Data.Project
   ) where
 
 import           Cascade.Api.Data.Prelude
+                                         hiding ( Id )
 import qualified Cascade.Api.Data.Prelude      as Prelude
 import           Control.Lens.TH                ( makeWrapped )
 import           Data.Aeson                     ( FromJSON

--- a/cascade-api/src/Cascade/Api/Data/Project.hs
+++ b/cascade-api/src/Cascade/Api/Data/Project.hs
@@ -11,14 +11,15 @@ Portability : POSIX
 -}
 
 module Cascade.Api.Data.Project
-  ( Id(..)
-  , Project
+  ( Project
+  , Id
   , Readable(..)
   , Creatable(..)
   , Updatable(..)
   ) where
 
 import           Cascade.Api.Data.Prelude
+import qualified Cascade.Api.Data.Prelude      as Prelude
 import           Control.Lens.TH                ( makeWrapped )
 import           Data.Aeson                     ( FromJSON
                                                 , ToJSON
@@ -28,14 +29,9 @@ import           Servant.API                    ( FromHttpApiData
                                                 , ToHttpApiData
                                                 )
 
-newtype Id = Id
-  { unId :: UUID }
-  deriving stock Generic
-  deriving newtype (Show, Eq, Ord, FromHttpApiData, ToHttpApiData, FromJSON, ToJSON)
-
-makeWrapped ''Id
-
 data Project
+
+type Id = Prelude.Id Project
 
 data instance Readable Project = ProjectR
   { id   :: Id

--- a/cascade-api/src/Cascade/Api/Data/Project.hs
+++ b/cascade-api/src/Cascade/Api/Data/Project.hs
@@ -18,9 +18,8 @@ module Cascade.Api.Data.Project
   , Updatable(..)
   ) where
 
+import qualified Cascade.Api.Data.Id           as Data
 import           Cascade.Api.Data.Prelude
-                                         hiding ( Id )
-import qualified Cascade.Api.Data.Prelude      as Prelude
 import           Data.Aeson                     ( FromJSON
                                                 , ToJSON
                                                 )
@@ -28,7 +27,7 @@ import           Data.Generics.Labels           ( )
 
 data Project
 
-type Id = Prelude.Id Project
+type Id = Data.Id Project
 
 data instance Readable Project = ProjectR
   { id   :: Id

--- a/cascade-api/src/Cascade/Api/Data/Project.hs
+++ b/cascade-api/src/Cascade/Api/Data/Project.hs
@@ -21,14 +21,10 @@ module Cascade.Api.Data.Project
 import           Cascade.Api.Data.Prelude
                                          hiding ( Id )
 import qualified Cascade.Api.Data.Prelude      as Prelude
-import           Control.Lens.TH                ( makeWrapped )
 import           Data.Aeson                     ( FromJSON
                                                 , ToJSON
                                                 )
 import           Data.Generics.Labels           ( )
-import           Servant.API                    ( FromHttpApiData
-                                                , ToHttpApiData
-                                                )
 
 data Project
 

--- a/cascade-api/test/Cascade/Api/Hedgehog/Gen/Api/Project.hs
+++ b/cascade-api/test/Cascade/Api/Hedgehog/Gen/Api/Project.hs
@@ -15,8 +15,7 @@ module Cascade.Api.Hedgehog.Gen.Api.Project
   ) where
 
 import           Cascade.Api.Data.Project
-import qualified Cascade.Api.Data.Project      as Project
-import qualified Cascade.Api.Hedgehog.Gen      as Gen
+import qualified Cascade.Api.Hedgehog.Gen.Id   as Gen
 import           Hedgehog
 import qualified Hedgehog.Gen                  as Gen
 import qualified Hedgehog.Range                as Range
@@ -25,10 +24,8 @@ class ProjectGenerator (f :: Type -> Type) where
   project :: MonadGen m => m (f Project)
 
 instance ProjectGenerator Readable where
-  project = ProjectR <$> id <*> name
-   where
-    id   = Gen.uuid |> fmap Project.Id
-    name = Gen.text (Range.linear 8 32) Gen.alphaNum
+  project = ProjectR <$> Gen.id <*> name
+    where name = Gen.text (Range.linear 8 32) Gen.alphaNum
 
 instance ProjectGenerator Creatable where
   project = ProjectC <$> name

--- a/cascade-api/test/Cascade/Api/Hedgehog/Gen/Id.hs
+++ b/cascade-api/test/Cascade/Api/Hedgehog/Gen/Id.hs
@@ -1,0 +1,10 @@
+module Cascade.Api.Hedgehog.Gen.Id
+  ( id
+  ) where
+
+import           Cascade.Api.Data.Prelude       ( Id(..) )
+import qualified Cascade.Api.Hedgehog.Gen      as Gen
+import           Hedgehog
+
+id :: MonadGen m => m (Id entity)
+id = Gen.uuid |> fmap Id

--- a/cascade-api/test/Cascade/Api/Hedgehog/Gen/Id.hs
+++ b/cascade-api/test/Cascade/Api/Hedgehog/Gen/Id.hs
@@ -2,9 +2,9 @@ module Cascade.Api.Hedgehog.Gen.Id
   ( id
   ) where
 
-import           Cascade.Api.Data.Prelude       ( Id(..) )
+import           Cascade.Api.Data.Id
 import qualified Cascade.Api.Hedgehog.Gen      as Gen
 import           Hedgehog
 
 id :: MonadGen m => m (Id entity)
-id = Gen.uuid |> fmap Id
+id = Id <$> Gen.uuid

--- a/cascade-api/test/Test/Cascade/Api/StateMachine.hs
+++ b/cascade-api/test/Test/Cascade/Api/StateMachine.hs
@@ -17,9 +17,9 @@ module Test.Cascade.Api.StateMachine
 import qualified Cascade.Api
 import           Cascade.Api.Data.Project
 import qualified Cascade.Api.Data.Project      as Project
-import qualified Cascade.Api.Hedgehog.Gen      as Gen
 import qualified Cascade.Api.Hedgehog.Gen.Api.Project
                                                as Gen
+import qualified Cascade.Api.Hedgehog.Gen.Id   as Gen
 import qualified Cascade.Api.Network.TestClient.Api.Projects
                                                as Cascade.Api.Projects
 import qualified Cascade.Api.Servant.Response  as Response
@@ -181,8 +181,7 @@ c_addNotExistingId :: forall g m
                    => Applicative m => Command g m Model
 c_addNotExistingId =
   let generator :: Model Symbolic -> Maybe (g (AddNotExistingId Symbolic))
-      generator _ =
-        Gen.uuid |> fmap Project.Id |> fmap AddNotExistingId |> Just
+      generator _ = Gen.id |> fmap AddNotExistingId |> Just
 
       execute :: AddNotExistingId Concrete -> m Project.Id
       execute (AddNotExistingId id) = pure id


### PR DESCRIPTION
There is no need to define `Id` for each entity multiple times. Just apply the phantom-type variable for each entity.