### PR TITLE
Add setup script to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ else
 	cd $(dir) && $(MAKE) wtest
 endif
 
-wtest-api: 
+wtest-api:
 	$(MAKE) wtest dir=cascade-api
 
 clean:
 	cabal new-clean
 	git clean -Xdf
+
+setup:
+	git config core.hooksPath .githooks
 
 .PHONY: wtest wtest-api clean

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ clean:
 setup:
 	git config core.hooksPath .githooks
 
-.PHONY: wtest wtest-api clean
+.PHONY: wtest wtest-api clean setup


### PR DESCRIPTION
This PR adds the `setup` command to Makefile which enables custom githooks directory.