### PR TITLE
Convert GHC warnings to errors

### DIFF
--- a/cascade-api/cascade-api.cabal
+++ b/cascade-api/cascade-api.cabal
@@ -90,7 +90,7 @@ common common-options
   -- https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html
   -- This list taken from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3#
   -- Enable all warnings with -Weverything, then disable the ones we don’t care about
-  ghc-options:         -Weverything
+  ghc-options:         -Werror -Weverything
                        -- missing-exported-signatures turns off the more strict -Wmissing-signatures.
                        -- See https://ghc.haskell.org/trac/ghc/ticket/14794#ticket
                        -Wno-missing-exported-signatures

--- a/cascade-api/src/Cascade/Api/Database/Project.hs
+++ b/cascade-api/src/Cascade/Api/Database/Project.hs
@@ -18,9 +18,6 @@ module Cascade.Api.Database.Project
 
 import qualified Cascade.Api.Data.Project      as Project
 import qualified Cascade.Api.Data.WrappedC     as Wrapped
-import           Control.Lens                   ( _Wrapped'
-                                                , view
-                                                )
 import           Data.Generics.Labels           ( )
 import           Database.Beam                  ( Beamable
                                                 , C

--- a/cascade-api/src/Cascade/Api/Effect/Database.hs
+++ b/cascade-api/src/Cascade/Api/Effect/Database.hs
@@ -58,7 +58,6 @@ import qualified Database.PostgreSQL.Simple    as Postgres
 import           GHC.Generics
 import           Polysemy                       ( Embed
                                                 , Member
-                                                , Members
                                                 , Sem
                                                 , embed
                                                 , interpret

--- a/cascade-api/src/Cascade/Api/Effect/Database/User.hs
+++ b/cascade-api/src/Cascade/Api/Effect/Database/User.hs
@@ -35,10 +35,8 @@ import           Database.Beam                  ( SqlEq((==.))
                                                 , default_
                                                 , exists_
                                                 , filter_
-                                                , guard_
                                                 , insertExpressions
                                                 , select
-                                                , subselect_
                                                 , val_
                                                 , (||.)
                                                 )

--- a/cascade-api/src/Cascade/Api/Network/Server/Api/Authentication.hs
+++ b/cascade-api/src/Cascade/Api/Network/Server/Api/Authentication.hs
@@ -33,7 +33,6 @@ import           Cascade.Api.Servant.Authentication
 import           Control.Lens                   ( (^.)
                                                 , _Wrapped'
                                                 )
-import qualified Data.ByteString               as W8
 import           Polysemy                       ( Members
                                                 , Sem
                                                 )

--- a/cascade-cli/cascade-cli.cabal
+++ b/cascade-cli/cascade-cli.cabal
@@ -76,7 +76,7 @@ common common-options
   -- https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html
   -- This list taken from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3#
   -- Enable all warnings with -Weverything, then disable the ones we don’t care about
-  ghc-options:         -Weverything
+  ghc-options:         -Werror -Weverything
                        -- missing-exported-signatures turns off the more strict -Wmissing-signatures.
                        -- See https://ghc.haskell.org/trac/ghc/ticket/14794#ticket
                        -Wno-missing-exported-signatures

--- a/cascade-prelude/cascade-prelude.cabal
+++ b/cascade-prelude/cascade-prelude.cabal
@@ -75,7 +75,7 @@ common common-options
   -- https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html
   -- This list taken from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3#
   -- Enable all warnings with -Weverything, then disable the ones we don’t care about
-  ghc-options:         -Weverything
+  ghc-options:         -Werror -Weverything
                        -- missing-exported-signatures turns off the more strict -Wmissing-signatures.
                        -- See https://ghc.haskell.org/trac/ghc/ticket/14794#ticket
                        -Wno-missing-exported-signatures


### PR DESCRIPTION
There were some GHC warnings in the CI process.
This PR obligates that there should not be any warning in the source code during compilation.