### PR TITLE
Disable ubuntu-latest builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os:
+          # Ubuntu builds disabled due to issue with installing libjwt-dev@1.12.x
+          # TODO: enable it when it's possible to install the lib
+          # - ubuntu-latest
+          - macOS-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I was not able to install the specific version of `libjwt-dev` we need on the Ubuntu machine. If anyone knows how to do it, please let us know.
We need to install `>= 1.12.0`.